### PR TITLE
Make rotation of glyphs optional

### DIFF
--- a/include/VFRendering/GlyphRenderer.hxx
+++ b/include/VFRendering/GlyphRenderer.hxx
@@ -6,6 +6,9 @@
 namespace VFRendering {
 class GlyphRenderer : public VectorFieldRenderer {
 public:
+    enum Option {
+      ROTATE_GLYPHS = 1000
+    };
 
     GlyphRenderer(const View& view, const VectorField& vf);
     virtual ~GlyphRenderer();
@@ -33,6 +36,13 @@ private:
     unsigned int m_num_indices = 0;
     unsigned int m_num_instances = 0;
 };
+
+namespace Utilities {
+template<>
+struct Options::Option<GlyphRenderer::Option::ROTATE_GLYPHS> {
+    bool default_value = true;
+};
+}
 }
 
 #endif

--- a/include/shaders/glyphs.frag.glsl.hxx
+++ b/include/shaders/glyphs.frag.glsl.hxx
@@ -1,7 +1,7 @@
-#ifndef ARROWS_FRAG_GLSL_HXX
-#define ARROWS_FRAG_GLSL_HXX
+#ifndef GLYPHS_FRAG_GLSL_HXX
+#define GLYPHS_FRAG_GLSL_HXX
 
-static const std::string ARROWS_FRAG_GLSL = R"LITERAL(
+static const std::string GLYPHS_FRAG_GLSL = R"LITERAL(
 #version 330
 uniform vec3 uLightPosition;
 in vec3 vfPosition;

--- a/include/shaders/glyphs.vert.glsl.hxx
+++ b/include/shaders/glyphs.vert.glsl.hxx
@@ -1,7 +1,7 @@
-#ifndef ARROWS_VERT_GLSL_HXX
-#define ARROWS_VERT_GLSL_HXX
+#ifndef GLYPHS_VERT_GLSL_HXX
+#define GLYPHS_VERT_GLSL_HXX
 
-static const std::string ARROWS_VERT_GLSL = R"LITERAL(
+static const std::string GLYPHS_ROTATED_VERT_GLSL = R"LITERAL(
 #version 330
 uniform mat4 uProjectionMatrix;
 uniform mat4 uModelviewMatrix;
@@ -44,6 +44,37 @@ void main(void) {
   if (is_visible(ivInstanceOffset, ivInstanceDirection) && direction_length > 0) {
     vfColor = colormap(normalize(ivInstanceDirection));
     mat3 instanceMatrix = direction_length * matrixFromDirection(ivInstanceDirection/direction_length);
+    vfNormal = (uModelviewMatrix * vec4(instanceMatrix*ivNormal, 0.0)).xyz;
+    vfPosition = (uModelviewMatrix * vec4(instanceMatrix*ivPosition+ivInstanceOffset, 1.0)).xyz;
+    gl_Position = uProjectionMatrix * vec4(vfPosition, 1.0);
+  } else {
+    gl_Position = vec4(2.0, 2.0, 2.0, 0.0);
+  }
+}
+)LITERAL";
+
+static const std::string GLYPHS_UNROTATED_VERT_GLSL = R"LITERAL(
+#version 330
+uniform mat4 uProjectionMatrix;
+uniform mat4 uModelviewMatrix;
+uniform vec2 uZRange;
+in vec3 ivPosition;
+in vec3 ivNormal;
+in vec3 ivInstanceOffset;
+in vec3 ivInstanceDirection;
+out vec3 vfPosition;
+out vec3 vfNormal;
+out vec3 vfColor;
+
+vec3 colormap(vec3 direction);
+
+bool is_visible(vec3 position, vec3 direction);
+
+void main(void) {
+  float direction_length = length(ivInstanceDirection);
+  if (is_visible(ivInstanceOffset, ivInstanceDirection) && direction_length > 0) {
+    vfColor = colormap(normalize(ivInstanceDirection));
+    mat3 instanceMatrix = mat3(direction_length);
     vfNormal = (uModelviewMatrix * vec4(instanceMatrix*ivNormal, 0.0)).xyz;
     vfPosition = (uModelviewMatrix * vec4(instanceMatrix*ivPosition+ivInstanceOffset, 1.0)).xyz;
     gl_Position = uProjectionMatrix * vec4(vfPosition, 1.0);

--- a/src/GlyphRenderer.cxx
+++ b/src/GlyphRenderer.cxx
@@ -78,6 +78,7 @@ void GlyphRenderer::optionsHaveChanged(const std::vector<int>& changed_options) 
         switch (option_index) {
         case View::Option::COLORMAP_IMPLEMENTATION:
         case View::Option::IS_VISIBLE_IMPLEMENTATION:
+        case GlyphRenderer::Option::ROTATE_GLYPHS:
             update_shader = true;
             break;
         }
@@ -132,10 +133,15 @@ void GlyphRenderer::updateShaderProgram() {
     if (m_program) {
         glDeleteProgram(m_program);
     }
-    std::string vertex_shader_source = ARROWS_VERT_GLSL;
+    std::string vertex_shader_source;
+    if (options().get<GlyphRenderer::Option::ROTATE_GLYPHS>()) {
+        vertex_shader_source = GLYPHS_ROTATED_VERT_GLSL;
+    } else {
+        vertex_shader_source = GLYPHS_UNROTATED_VERT_GLSL;
+    }
     vertex_shader_source += options().get<View::Option::COLORMAP_IMPLEMENTATION>();
     vertex_shader_source += options().get<View::Option::IS_VISIBLE_IMPLEMENTATION>();
-    std::string fragment_shader_source = ARROWS_FRAG_GLSL;
+    std::string fragment_shader_source = GLYPHS_FRAG_GLSL;
     m_program = Utilities::createProgram(vertex_shader_source, fragment_shader_source, {"ivPosition", "ivNormal", "ivInstanceOffset", "ivInstanceDirection"});
 }
 


### PR DESCRIPTION
This commit allows you to disable the glyph rotation in the `ParallelepipedRenderer`. Having seperate vertex shader implementations might not be the best approach for adding further customizations, but for this it should be fine and making it an option instead of a parameter avoids changing the Renderer interface.